### PR TITLE
test: expand unit coverage for env, auth headers, and storage

### DIFF
--- a/tests/unit/auth-headers.spec.ts
+++ b/tests/unit/auth-headers.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest';
+import {
+  authHeaders,
+  authHeadersArrayBuffer,
+  authHeadersFormData,
+  authHeadersWithParams,
+} from '@/utils/auth-headers';
+
+describe('authHeaders helpers', () => {
+  const token = 'test-token-123';
+
+  it('authHeaders sets Bearer Authorization', () => {
+    expect(authHeaders(token)).toEqual({
+      headers: { Authorization: 'Bearer test-token-123' },
+    });
+  });
+
+  it('authHeadersArrayBuffer sets Authorization and arraybuffer responseType', () => {
+    expect(authHeadersArrayBuffer(token)).toEqual({
+      headers: { Authorization: 'Bearer test-token-123' },
+      responseType: 'arraybuffer',
+    });
+  });
+
+  it('authHeadersFormData sets multipart Content-Type', () => {
+    expect(authHeadersFormData(token)).toEqual({
+      headers: {
+        Authorization: 'Bearer test-token-123',
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+  });
+
+  it('authHeadersWithParams includes query params', () => {
+    const params = new URLSearchParams({ skip: '0', limit: '10' });
+    expect(authHeadersWithParams(token, params)).toEqual({
+      headers: { Authorization: 'Bearer test-token-123' },
+      params,
+    });
+  });
+});

--- a/tests/unit/env.spec.ts
+++ b/tests/unit/env.spec.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+describe('env host validation', () => {
+  const originalEnv = { ...import.meta.env };
+
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    // restore mutable env keys used by the module under test
+    for (const key of Object.keys(import.meta.env)) {
+      if (!(key in originalEnv)) {
+        delete (import.meta.env as Record<string, unknown>)[key];
+      }
+    }
+    Object.assign(import.meta.env, originalEnv);
+  });
+
+  async function loadEnvWith(apiHost: string) {
+    (import.meta.env as Record<string, string>).VITE_APP_API = apiHost;
+    (import.meta.env as Record<string, string>).VITE_APP_ENV = 'test';
+    (import.meta.env as Record<string, string>).VITE_APP_NAME = 'ChaFan';
+    (import.meta.env as Record<string, string>).VITE_GIT_COMMIT = 'abc123456789';
+    (import.meta.env as Record<string, string>).VITE_GIT_BRANCH = 'master';
+    (import.meta.env as Record<string, string>).VITE_GIT_COMMIT_TIME = '2026-01-01T00:00:00Z';
+    (import.meta.env as Record<string, string>).VITE_GIT_TAGS = '';
+    return import('@/env');
+  }
+
+  it('accepts production api.cha.fan host', async () => {
+    const env = await loadEnvWith('api.cha.fan');
+    expect(env.apiUrl).toBe('https://api.cha.fan/api/v1');
+    expect(env.wsUrl).toBe('wss://api.cha.fan/api/v1');
+  });
+
+  it('accepts api_dev.cha.fan style hosts', async () => {
+    const env = await loadEnvWith('api_dev.cha.fan');
+    expect(env.apiUrl).toBe('https://api_dev.cha.fan/api/v1');
+  });
+
+  it('accepts localhost with port for development', async () => {
+    const env = await loadEnvWith('localhost:8000');
+    expect(env.apiUrl).toBe('https://localhost:8000/api/v1');
+  });
+
+  it('rejects disallowed hosts', async () => {
+    await expect(loadEnvWith('evil.example.com')).rejects.toThrow(/Invalid API host/);
+  });
+
+  it('exposes buildInfo commit short hash', async () => {
+    const env = await loadEnvWith('api.cha.fan');
+    expect(env.buildInfo.commitHashShort).toBe('abc12345');
+    expect(env.buildInfo.branch).toBe('master');
+  });
+});

--- a/tests/unit/local-storage.spec.ts
+++ b/tests/unit/local-storage.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import {
+  getLocalToken,
+  saveLocalToken,
+  removeLocalToken,
+  getLocalValue,
+  setLocalValue,
+  saveLocalEdit,
+  loadLocalEdit,
+  clearLocalEdit,
+} from '@/utils/local-storage';
+
+describe('local-storage helpers', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('saves and reads auth token', () => {
+    expect(getLocalToken()).toBeNull();
+    saveLocalToken('abc');
+    expect(getLocalToken()).toBe('abc');
+    removeLocalToken();
+    expect(getLocalToken()).toBeNull();
+  });
+
+  it('getLocalValue returns default when missing', () => {
+    expect(getLocalValue('missing', 'fallback')).toBe('fallback');
+  });
+
+  it('setLocalValue and getLocalValue round-trip', () => {
+    setLocalValue('theme', 'dark');
+    expect(getLocalValue('theme')).toBe('dark');
+  });
+
+  it('save/load/clear local edit drafts', () => {
+    const edit = { title: 'draft', body: 'hello', editor: 'tiptap' as const, visible: true };
+    saveLocalEdit('answer', 'uuid-1', edit as any);
+    const loaded = loadLocalEdit('answer', 'uuid-1');
+    expect(loaded).not.toBeNull();
+    expect(loaded!.edit).toEqual(edit);
+    expect(loaded!.createdAt).toBeTruthy();
+
+    clearLocalEdit('answer', 'uuid-1');
+    expect(loadLocalEdit('answer', 'uuid-1')).toBeNull();
+  });
+
+  it('returns null when localStorage throws on load', () => {
+    vi.spyOn(Storage.prototype, 'getItem').mockImplementation(() => {
+      throw new Error('quota');
+    });
+    expect(getLocalToken()).toBeNull();
+    expect(getLocalValue('x', 'd')).toBe('d');
+  });
+});


### PR DESCRIPTION
Adds unit tests for env handling, auth headers, and localStorage.

Part of the Vue 3 migration PR stack (4/8).