### PR TITLE
chore: align Makefile with Yarn scripts and wire lint-staged

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,38 @@
-all:
-	yarn install
-	yarn run build
+.PHONY: all install dev build fix lint lint-css test quality precommit
 
+all: install build
+
+install:
+	yarn install
+
+dev:
+	yarn dev
+
+build:
+	yarn build
+
+# Auto-fix ESLint + Stylelint + Prettier on src
 fix:
-	yarn run eslint --fix .
-	yarn run prettier -w .
+	yarn lint:fix
+	yarn lint:css:fix
+	yarn prettier -w "src/**/*.{ts,vue,css,scss,json}"
+
+lint:
+	yarn lint
+
+lint-css:
+	yarn lint:css
+
+test:
+	yarn test:unit
+
+# Same hard gates as CI (lint + CSS + unit tests)
+quality:
+	yarn quality
+
+# Run lint-staged (wire as a git pre-commit hook if desired)
+precommit:
+	yarn precommit
 
 prod-pr:
 	gh pr create -B prod

--- a/README.md
+++ b/README.md
@@ -48,11 +48,13 @@ Open the URL Vite prints (default `http://localhost:5173`).
 **4. Quality checks**
 
 ```bash
+yarn quality     # lint + CSS lint + unit tests
 yarn lint
 yarn lint:css
 yarn test:unit
-yarn typecheck   # soft gate while migration type debt remains
+yarn typecheck   # soft gate (available once vue-tsc is installed)
 yarn build
+yarn precommit   # lint-staged on staged files (optional git hook)
 ```
 
 ## Production-like local serve (optional)

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
     "lint:fix": "eslint src/ --fix",
     "lint:css": "stylelint \"src/**/*.{css,scss,vue}\"",
     "lint:css:fix": "stylelint \"src/**/*.{css,scss,vue}\" --fix",
-    "typecheck": "vue-tsc --noEmit -p tsconfig.json"
+    "typecheck": "vue-tsc --noEmit -p tsconfig.json",
+    "quality": "yarn lint && yarn lint:css && yarn test:unit",
+    "precommit": "lint-staged"
   },
   "dependencies": {
     "@sentry/tracing": "^7.119.2",
@@ -107,5 +109,16 @@
     "last 2 versions",
     "not dead"
   ],
-  "packageManager": "yarn@4.9.1"
+  "packageManager": "yarn@4.9.1",
+  "lint-staged": {
+    "src/**/*.{ts,vue}": [
+      "eslint --fix"
+    ],
+    "src/**/*.{css,scss,vue}": [
+      "stylelint --fix"
+    ],
+    "src/**/*.{ts,vue,css,scss,json,md}": [
+      "prettier --write"
+    ]
+  }
 }


### PR DESCRIPTION
Aligns the Makefile with Yarn scripts and wires up lint-staged for pre-commit hooks.

Independent of `master`; no hard dependency on other stack branches.