### PR TITLE
Inject content OG meta for chat crawlers (Vue 3)

### DIFF
--- a/functions/_middleware.ts
+++ b/functions/_middleware.ts
@@ -1,0 +1,134 @@
+/**
+ * Cloudflare Pages middleware: inject per-content Open Graph tags for crawlers.
+ *
+ * Chat apps and social crawlers do not execute the Vue SPA, so they only see
+ * static index.html meta. For /questions|articles|submissions/:id requests from
+ * known bots (or ?__og_preview=1), we fetch the public API and rewrite the HTML.
+ */
+
+import {
+  defaultOgImage,
+  injectOgTags,
+  isCrawlerRequest,
+  matchContentRoute,
+  normalizeDescription,
+  resolveApiBase,
+  resolveSiteName,
+} from './lib/og';
+
+interface PagesContext {
+  request: Request;
+  next: (input?: Request | string, init?: RequestInit) => Promise<Response>;
+  env: Record<string, unknown> & {
+    ASSETS?: { fetch: typeof fetch };
+  };
+}
+
+export const onRequest = async (context: PagesContext): Promise<Response> => {
+  const { request, next, env } = context;
+  const url = new URL(request.url);
+
+  // Skip non-document requests early.
+  if (request.method !== 'GET' && request.method !== 'HEAD') {
+    return next();
+  }
+
+  // Never rewrite static assets.
+  if (looksLikeStaticAsset(url.pathname)) {
+    return next();
+  }
+
+  const route = matchContentRoute(url.pathname);
+  if (!route) {
+    return next();
+  }
+
+  const ua = request.headers.get('user-agent');
+  if (!isCrawlerRequest(ua, url)) {
+    return next();
+  }
+
+  // Serve the SPA shell (Pages _redirects maps /* → /index.html).
+  const assetResponse = await next();
+  const contentType = assetResponse.headers.get('content-type') || '';
+  if (!contentType.includes('text/html')) {
+    return assetResponse;
+  }
+
+  let html: string;
+  try {
+    html = await assetResponse.text();
+  } catch {
+    return assetResponse;
+  }
+
+  const meta = await fetchContentMeta(route.apiPath, route.pick, env);
+  if (!meta) {
+    // Still fix legacy og.* → proper tags on the shell for this response.
+    const fixed = injectOgTags(html, {
+      title: resolveSiteName(env),
+      description: normalizeDescription(undefined),
+      url: `${url.origin}${url.pathname}`,
+      siteName: resolveSiteName(env),
+      image: defaultOgImage(url.origin),
+    });
+    return htmlResponse(fixed, assetResponse);
+  }
+
+  const rewritten = injectOgTags(html, {
+    title: meta.title,
+    description: normalizeDescription(meta.description),
+    url: `${url.origin}${url.pathname}`,
+    siteName: resolveSiteName(env),
+    image: defaultOgImage(url.origin),
+  });
+
+  return htmlResponse(rewritten, assetResponse);
+};
+
+function looksLikeStaticAsset(pathname: string): boolean {
+  return /\.(js|css|map|png|jpe?g|gif|svg|ico|webp|woff2?|ttf|eot|json|txt|xml|webmanifest)$/i.test(
+    pathname
+  );
+}
+
+async function fetchContentMeta(
+  apiPath: string,
+  pick: ReturnType<typeof matchContentRoute> extends null
+    ? never
+    : NonNullable<ReturnType<typeof matchContentRoute>>['pick'],
+  env: Record<string, unknown>
+): Promise<{ title: string; description?: string } | null> {
+  const apiBase = resolveApiBase(env);
+  const endpoint = `${apiBase}${apiPath}`;
+  try {
+    const res = await fetch(endpoint, {
+      headers: {
+        Accept: 'application/json',
+        // Identify ourselves; some APIs rate-limit anonymous bots.
+        'User-Agent': 'Chafan-OG-Preview/1.0 (+https://cha.fan)',
+      },
+    });
+    if (!res.ok) {
+      return null;
+    }
+    const body = (await res.json()) as Record<string, unknown>;
+    return pick(body);
+  } catch {
+    return null;
+  }
+}
+
+function htmlResponse(html: string, base: Response): Response {
+  const headers = new Headers(base.headers);
+  headers.set('content-type', 'text/html; charset=utf-8');
+  // Ensure crawlers don't get a long-lived wrong cache if API content changes.
+  headers.set('cache-control', 'public, max-age=300, must-revalidate');
+  // Body length changed after rewrite.
+  headers.delete('content-length');
+  return new Response(html, {
+    status: base.status,
+    statusText: base.statusText,
+    headers,
+  });
+}

--- a/functions/lib/og.ts
+++ b/functions/lib/og.ts
@@ -1,0 +1,202 @@
+/**
+ * Pure helpers for Open Graph / Twitter meta injection (Cloudflare Pages Functions).
+ * Kept free of runtime globals so unit tests can import this module.
+ */
+
+export const DEFAULT_DESCRIPTION = 'Chafan 茶饭 - 有深度的社交问答网站';
+export const DEFAULT_TITLE = 'Chafan 茶饭';
+
+/** Content routes that should receive dynamic OG tags. */
+export const CONTENT_ROUTE_PATTERNS: ReadonlyArray<{
+  re: RegExp;
+  /** API path under /api/v1 */
+  apiPath: (id: string) => string;
+  /** Map JSON body → title + description */
+  pick: (body: Record<string, unknown>) => { title: string; description?: string } | null;
+}> = [
+  {
+    re: /^\/questions\/([A-Za-z0-9]+)$/,
+    apiPath: (id) => `/questions/${id}`,
+    pick: (body) => {
+      const title = typeof body.title === 'string' ? body.title : null;
+      if (!title) return null;
+      const desc = body.desc as { rendered_text?: string } | null | undefined;
+      return {
+        title,
+        description: desc?.rendered_text || undefined,
+      };
+    },
+  },
+  {
+    re: /^\/articles\/([A-Za-z0-9]+)$/,
+    apiPath: (id) => `/articles/${id}`,
+    pick: (body) => {
+      const title = typeof body.title === 'string' ? body.title : null;
+      if (!title) return null;
+      const bodyField = body.body as { rendered_text?: string } | null | undefined;
+      return {
+        title,
+        description: bodyField?.rendered_text || undefined,
+      };
+    },
+  },
+  {
+    re: /^\/submissions\/([A-Za-z0-9]+)$/,
+    apiPath: (id) => `/submissions/${id}`,
+    pick: (body) => {
+      const title = typeof body.title === 'string' ? body.title : null;
+      if (!title) return null;
+      const desc = body.desc as { rendered_text?: string } | null | undefined;
+      return {
+        title,
+        description: desc?.rendered_text || undefined,
+      };
+    },
+  },
+];
+
+/** Well-known crawlers / chat unfurl bots. */
+const CRAWLER_UA =
+  /facebookexternalhit|Facebot|Twitterbot|LinkedInBot|Slackbot|Discordbot|TelegramBot|WhatsApp|SkypeUriPreview|Applebot|Googlebot|bingbot|Baiduspider|YandexBot|DuckDuckBot|Embedly|redditbot|Pinterest|vkShare|W3C_Validator|Slurp|ia_archiver|MicroMessenger|Bytespider|PetalBot|Sogou|YisouSpider|Slack-ImgProxy|meta-externalagent/i;
+
+export function isCrawlerRequest(userAgent: string | null, url: URL): boolean {
+  // Force dynamic meta for manual verification: ?__og_preview=1
+  if (url.searchParams.get('__og_preview') === '1') {
+    return true;
+  }
+  if (!userAgent) {
+    return false;
+  }
+  return CRAWLER_UA.test(userAgent);
+}
+
+export function matchContentRoute(
+  pathname: string
+): { apiPath: string; pick: (typeof CONTENT_ROUTE_PATTERNS)[number]['pick'] } | null {
+  for (const route of CONTENT_ROUTE_PATTERNS) {
+    const m = pathname.match(route.re);
+    if (m) {
+      return { apiPath: route.apiPath(m[1]), pick: route.pick };
+    }
+  }
+  return null;
+}
+
+export function escapeHtmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;');
+}
+
+/** Collapse whitespace and cap length for OG description. */
+export function normalizeDescription(text: string | undefined, maxLen = 200): string {
+  if (!text) {
+    return DEFAULT_DESCRIPTION;
+  }
+  const collapsed = text.replace(/\s+/g, ' ').trim();
+  if (!collapsed) {
+    return DEFAULT_DESCRIPTION;
+  }
+  if (collapsed.length <= maxLen) {
+    return collapsed;
+  }
+  return collapsed.slice(0, maxLen - 1).trimEnd() + '…';
+}
+
+export function defaultOgImage(origin: string): string {
+  return `${origin}/img/icons/android-chrome-512x512.png`;
+}
+
+export interface OgPayload {
+  title: string;
+  description: string;
+  url: string;
+  siteName?: string;
+  image?: string;
+  type?: string;
+}
+
+/**
+ * Rewrite HTML head meta for Open Graph / Twitter / description / title.
+ * Accepts both legacy `og.*` and correct `og:*` property names.
+ */
+export function injectOgTags(html: string, payload: OgPayload): string {
+  const title = escapeHtmlAttr(payload.title);
+  const description = escapeHtmlAttr(payload.description);
+  const url = escapeHtmlAttr(payload.url);
+  const image = escapeHtmlAttr(payload.image || '');
+  const siteName = escapeHtmlAttr(payload.siteName || DEFAULT_TITLE);
+  const type = escapeHtmlAttr(payload.type || 'article');
+
+  let out = html;
+
+  // <title>
+  if (/<title>[\s\S]*?<\/title>/i.test(out)) {
+    out = out.replace(/<title>[\s\S]*?<\/title>/i, `<title>${title}</title>`);
+  } else {
+    out = out.replace(/<\/head>/i, `<title>${title}</title>\n</head>`);
+  }
+
+  const setMeta = (attr: 'property' | 'name', key: string, content: string) => {
+    // Match either order: property/name before or after content=
+    const re = new RegExp(
+      `<meta\\s+[^>]*${attr}=["']${key.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}["'][^>]*>`,
+      'i'
+    );
+    const tag = `<meta ${attr}="${key}" content="${content}" />`;
+    if (re.test(out)) {
+      out = out.replace(re, tag);
+    } else {
+      out = out.replace(/<\/head>/i, `${tag}\n</head>`);
+    }
+  };
+
+  // Standard description
+  setMeta('name', 'description', description);
+  setMeta('property', 'description', description);
+
+  // Open Graph (correct colon form)
+  setMeta('property', 'og:title', title);
+  setMeta('property', 'og:description', description);
+  setMeta('property', 'og:url', url);
+  setMeta('property', 'og:type', type);
+  setMeta('property', 'og:site_name', siteName);
+  if (image) {
+    setMeta('property', 'og:image', image);
+  }
+
+  // Remove legacy dotted og.* tags so crawlers are not confused
+  out = out.replace(/<meta\s+[^>]*property=["']og\.[^"']+["'][^>]*>\s*/gi, '');
+
+  // Twitter card
+  setMeta('name', 'twitter:card', 'summary');
+  setMeta('name', 'twitter:title', title);
+  setMeta('name', 'twitter:description', description);
+  if (image) {
+    setMeta('name', 'twitter:image', image);
+  }
+
+  return out;
+}
+
+export function resolveApiBase(env: Record<string, unknown> | undefined): string {
+  const host =
+    (typeof env?.VUE_APP_API === 'string' && env.VUE_APP_API) ||
+    (typeof env?.VITE_APP_API === 'string' && env.VITE_APP_API) ||
+    'api.cha.fan';
+  // Host only (no scheme) as used by the Vue app; allow accidental full URL too.
+  if (host.startsWith('http://') || host.startsWith('https://')) {
+    return host.replace(/\/$/, '') + '/api/v1';
+  }
+  return `https://${host}/api/v1`;
+}
+
+export function resolveSiteName(env: Record<string, unknown> | undefined): string {
+  return (
+    (typeof env?.VUE_APP_NAME === 'string' && env.VUE_APP_NAME) ||
+    (typeof env?.VITE_APP_NAME === 'string' && env.VITE_APP_NAME) ||
+    DEFAULT_TITLE
+  );
+}

--- a/index.html
+++ b/index.html
@@ -42,11 +42,17 @@
     <meta name="keywords" content="Cha, Fan, Chafan, 茶饭, 社交, 问答" />
 
     <meta property="description" content="Chafan 茶饭 - 有深度的社交问答网站" />
-    <meta property="og.title" content="Chafan 茶饭" />
-    <meta property="og.site_name" content="%VITE_APP_NAME%" />
-    <meta property="og.description" content="Chafan 茶饭 - 有深度的社交问答网站" />
-    <meta property="og.type" content="article" />
-    <meta property="og.url" content="https://cha.fan" />
+    <meta property="og:title" content="Chafan 茶饭" />
+    <meta property="og:site_name" content="%VITE_APP_NAME%" />
+    <meta property="og:description" content="Chafan 茶饭 - 有深度的社交问答网站" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://cha.fan" />
+    <meta property="og:image" content="/img/icons/android-chrome-512x512.png" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Chafan 茶饭" />
+    <meta name="twitter:description" content="Chafan 茶饭 - 有深度的社交问答网站" />
+    <meta name="twitter:image" content="/img/icons/android-chrome-512x512.png" />
 
     <meta name="theme-color" content="#1976d2" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/public/index.html
+++ b/public/index.html
@@ -47,11 +47,17 @@
     <meta name="keywords" content="Cha, Fan, Chafan, 茶饭, 社交, 问答" />
 
     <meta property="description" content="Chafan 茶饭 - 有深度的社交问答网站" />
-    <meta property="og.title" content="Chafan 茶饭" />
-    <meta property="og.site_name" content="<%= VUE_APP_NAME %>" />
-    <meta property="og.description" content="Chafan 茶饭 - 有深度的社交问答网站" />
-    <meta property="og.type" content="article" />
-    <meta property="og.url" content="https://cha.fan" />
+    <meta property="og:title" content="Chafan 茶饭" />
+    <meta property="og:site_name" content="<%= VUE_APP_NAME %>" />
+    <meta property="og:description" content="Chafan 茶饭 - 有深度的社交问答网站" />
+    <meta property="og:type" content="article" />
+    <meta property="og:url" content="https://cha.fan" />
+    <meta property="og:image" content="/img/icons/android-chrome-512x512.png" />
+
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Chafan 茶饭" />
+    <meta name="twitter:description" content="Chafan 茶饭 - 有深度的社交问答网站" />
+    <meta name="twitter:image" content="/img/icons/android-chrome-512x512.png" />
 
     <meta name="theme-color" content="#1976d2" />
     <meta name="mobile-web-app-capable" content="yes" />

--- a/src/dom-utils.ts
+++ b/src/dom-utils.ts
@@ -29,23 +29,37 @@ export const postProcessViewerDOM = async (token: string, viewer: HTMLElement | 
   }
 };
 
+const setMetaContent = (selector: string, content: string) => {
+  document.querySelector(selector)?.setAttribute('content', content);
+};
+
+/**
+ * Update document title and Open Graph / Twitter meta for the current SPA route.
+ * Note: external chat crawlers do not run this — see functions/_middleware.ts.
+ */
 export const updateHead = (routePath: string, title: string, descriptionText?: string) => {
+  const absoluteUrl = `${window.location.origin}${routePath}`;
+  const ogImage = `${window.location.origin}/img/icons/android-chrome-512x512.png`;
+
   document.title = title;
-  document.querySelector('meta[property="og.title"]')?.setAttribute('content', title);
+
+  setMetaContent('meta[property="og:title"]', title);
+  setMetaContent('meta[name="twitter:title"]', title);
+
   if (appName) {
-    document.querySelector('meta[property="og.site_name"]')?.setAttribute('content', appName);
+    setMetaContent('meta[property="og:site_name"]', appName);
   }
+
   if (descriptionText) {
-    document.querySelector('meta[name="description"]')?.setAttribute('content', descriptionText);
-    document
-      .querySelector('meta[property="description"]')
-      ?.setAttribute('content', descriptionText);
-    document
-      .querySelector('meta[property="og.description"]')
-      ?.setAttribute('content', descriptionText);
+    setMetaContent('meta[name="description"]', descriptionText);
+    setMetaContent('meta[property="description"]', descriptionText);
+    setMetaContent('meta[property="og:description"]', descriptionText);
+    setMetaContent('meta[name="twitter:description"]', descriptionText);
   }
-  document.querySelector('meta[property="og.type"]')?.setAttribute('content', 'article');
-  document
-    .querySelector('meta[property="og.url"]')
-    ?.setAttribute('content', 'https://cha.fan' + routePath);
+
+  setMetaContent('meta[property="og:type"]', 'article');
+  setMetaContent('meta[property="og:url"]', absoluteUrl);
+  setMetaContent('meta[property="og:image"]', ogImage);
+  setMetaContent('meta[name="twitter:card"]', 'summary');
+  setMetaContent('meta[name="twitter:image"]', ogImage);
 };

--- a/tests/unit/og-meta.spec.ts
+++ b/tests/unit/og-meta.spec.ts
@@ -1,0 +1,163 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_DESCRIPTION,
+  DEFAULT_TITLE,
+  defaultOgImage,
+  escapeHtmlAttr,
+  injectOgTags,
+  isCrawlerRequest,
+  matchContentRoute,
+  normalizeDescription,
+  resolveApiBase,
+  resolveSiteName,
+} from '../../functions/lib/og';
+
+describe('functions/lib/og', () => {
+  describe('isCrawlerRequest', () => {
+    it('detects common chat/social bots', () => {
+      const url = new URL('https://preview.cha.fan/questions/abc');
+      expect(isCrawlerRequest('Discordbot/2.0', url)).toBe(true);
+      expect(isCrawlerRequest('facebookexternalhit/1.1', url)).toBe(true);
+      expect(isCrawlerRequest('Twitterbot/1.0', url)).toBe(true);
+      expect(isCrawlerRequest('Slackbot-LinkExpanding 1.0', url)).toBe(true);
+      expect(isCrawlerRequest('MicroMessenger', url)).toBe(true);
+      expect(isCrawlerRequest('Mozilla/5.0 (compatible; Googlebot/2.1)', url)).toBe(true);
+    });
+
+    it('does not treat normal browsers as crawlers', () => {
+      const url = new URL('https://preview.cha.fan/questions/abc');
+      expect(
+        isCrawlerRequest(
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0',
+          url
+        )
+      ).toBe(false);
+      expect(isCrawlerRequest(null, url)).toBe(false);
+    });
+
+    it('forces preview with ?__og_preview=1', () => {
+      const url = new URL('https://preview.cha.fan/questions/abc?__og_preview=1');
+      expect(isCrawlerRequest('Mozilla/5.0', url)).toBe(true);
+      expect(isCrawlerRequest(null, url)).toBe(true);
+    });
+  });
+
+  describe('matchContentRoute', () => {
+    it('matches questions / articles / submissions', () => {
+      expect(matchContentRoute('/questions/7e7QP9AoCJdUDBPa62VF')?.apiPath).toBe(
+        '/questions/7e7QP9AoCJdUDBPa62VF'
+      );
+      expect(matchContentRoute('/articles/abc123')?.apiPath).toBe('/articles/abc123');
+      expect(matchContentRoute('/submissions/xyz')?.apiPath).toBe('/submissions/xyz');
+    });
+
+    it('rejects non-content paths', () => {
+      expect(matchContentRoute('/')).toBeNull();
+      expect(matchContentRoute('/explore')).toBeNull();
+      expect(matchContentRoute('/questions/')).toBeNull();
+      expect(matchContentRoute('/questions/abc/extra')).toBeNull();
+      expect(matchContentRoute('/assets/index.js')).toBeNull();
+    });
+
+    it('picks title and description from question payload', () => {
+      const route = matchContentRoute('/questions/abc')!;
+      const picked = route.pick({
+        title: '测试问题',
+        desc: { rendered_text: '问题描述' },
+      });
+      expect(picked).toEqual({ title: '测试问题', description: '问题描述' });
+      expect(route.pick({})).toBeNull();
+    });
+  });
+
+  describe('normalizeDescription', () => {
+    it('falls back to default', () => {
+      expect(normalizeDescription(undefined)).toBe(DEFAULT_DESCRIPTION);
+      expect(normalizeDescription('   ')).toBe(DEFAULT_DESCRIPTION);
+    });
+
+    it('collapses whitespace and truncates', () => {
+      expect(normalizeDescription('a\n\nb   c')).toBe('a b c');
+      const long = '字'.repeat(250);
+      const out = normalizeDescription(long, 50);
+      expect(out.length).toBeLessThanOrEqual(50);
+      expect(out.endsWith('…')).toBe(true);
+    });
+  });
+
+  describe('escapeHtmlAttr', () => {
+    it('escapes attribute-sensitive characters', () => {
+      expect(escapeHtmlAttr('a&b"c<d>e')).toBe('a&amp;b&quot;c&lt;d&gt;e');
+    });
+  });
+
+  describe('injectOgTags', () => {
+    const shell = `<!DOCTYPE html><html><head>
+<title>PREPROD</title>
+<meta name="description" content="old desc" />
+<meta property="og.title" content="legacy" />
+<meta property="og:title" content="Chafan 茶饭" />
+<meta property="og:description" content="old" />
+<meta property="og:url" content="https://cha.fan" />
+</head><body></body></html>`;
+
+    it('rewrites title and og tags and strips legacy og.*', () => {
+      const out = injectOgTags(shell, {
+        title: '大家现在工作之余有什么爱好吗？',
+        description: '我花了不少时间看网络小说。',
+        url: 'https://preview.cha.fan/questions/7e7QP9AoCJdUDBPa62VF',
+        siteName: 'PREPROD',
+        image: 'https://preview.cha.fan/img/icons/android-chrome-512x512.png',
+      });
+
+      expect(out).toContain('<title>大家现在工作之余有什么爱好吗？</title>');
+      expect(out).toContain('property="og:title" content="大家现在工作之余有什么爱好吗？"');
+      expect(out).toContain('property="og:description" content="我花了不少时间看网络小说。"');
+      expect(out).toContain(
+        'property="og:url" content="https://preview.cha.fan/questions/7e7QP9AoCJdUDBPa62VF"'
+      );
+      expect(out).toContain('property="og:image"');
+      expect(out).toContain('name="twitter:card" content="summary"');
+      expect(out).not.toMatch(/property="og\./);
+    });
+
+    it('escapes HTML in injected values', () => {
+      const out = injectOgTags(shell, {
+        title: 'A <script> "x" & y',
+        description: 'desc',
+        url: 'https://cha.fan/q',
+      });
+      expect(out).toContain('A &lt;script&gt; &quot;x&quot; &amp; y');
+      expect(out).not.toContain('<script>');
+    });
+  });
+
+  describe('resolveApiBase / resolveSiteName', () => {
+    it('builds api base from host-only env', () => {
+      expect(resolveApiBase({ VUE_APP_API: 'api.cha.fan' })).toBe('https://api.cha.fan/api/v1');
+      expect(resolveApiBase({ VITE_APP_API: 'api_dev.cha.fan' })).toBe(
+        'https://api_dev.cha.fan/api/v1'
+      );
+      expect(resolveApiBase({})).toBe('https://api.cha.fan/api/v1');
+    });
+
+    it('accepts full URL env values', () => {
+      expect(resolveApiBase({ VUE_APP_API: 'https://api.cha.fan/' })).toBe(
+        'https://api.cha.fan/api/v1'
+      );
+    });
+
+    it('resolves site name', () => {
+      expect(resolveSiteName({ VUE_APP_NAME: 'PREPROD' })).toBe('PREPROD');
+      expect(resolveSiteName({})).toBe(DEFAULT_TITLE);
+    });
+  });
+
+  describe('defaultOgImage', () => {
+    it('points at the app icon under the request origin', () => {
+      expect(defaultOgImage('https://preview.cha.fan')).toBe(
+        'https://preview.cha.fan/img/icons/android-chrome-512x512.png'
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Chat unfurl bots never run the SPA, so they only saw the generic shell. This adds server-side Open Graph metadata for crawler requests via a Cloudflare Pages middleware.

- Add a Cloudflare Pages middleware (`functions/_middleware.ts`) that detects crawler requests, fetches the public question/article/submission APIs, and rewrites Open Graph tags with real content.
- Add `functions/lib/og.ts` with the OG-tag rewriting logic.
- Fix nonstandard `og.*` property names to `og:*`, add a default `og:image` and `twitter:card`.
- Update client `updateHead` (`src/dom-utils.ts`) to match, plus the `index.html` / `public/index.html` shells.
- Add unit coverage in `tests/unit/og-meta.spec.ts`.

## Files
- `functions/_middleware.ts` (new)
- `functions/lib/og.ts` (new)
- `tests/unit/og-meta.spec.ts` (new)
- `index.html`, `public/index.html`, `src/dom-utils.ts`