### PR TITLE
Add standalone preview E2E suite

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,56 @@
+# Preview E2E (standalone)
+
+Real-browser journeys against **https://preview.cha.fan**. Not part of CI —
+run it by hand after a deploy to preview to confirm basic functions still work.
+
+## Setup
+
+```bash
+yarn install                       # pulls @playwright/test + dotenv (devDeps)
+yarn playwright install chromium   # one-time browser download
+cp e2e/env.e2e.example env.e2e     # then fill E2E_EMAIL / E2E_PASSWORD
+```
+
+`env.e2e` is gitignored — never commit credentials.
+
+## Run
+
+No yarn run-scripts — a standalone launcher drives Playwright directly:
+
+```bash
+e2e/run.sh                    # headless, all journeys
+e2e/run.sh --headed           # watch the browser
+e2e/run.sh --ui               # Playwright UI mode
+e2e/run.sh --project=public   # only logged-out journeys (no credentials needed)
+```
+
+Extra args pass straight through to `playwright test`, e.g. run one journey:
+
+```bash
+e2e/run.sh e2e/journeys/03-create-question-answer.spec.ts
+```
+
+The HTML report lands in `playwright-report/` (open with
+`yarn playwright show-report`).
+
+## Coverage
+
+1. Login (test account, via `auth.setup.ts` — runs once, state reused)
+2. Public browse (home, explore, login page, test site) — no credentials
+3. Logged-in site tabs (问题 / 分享)
+4. Create question + answer on `/sites/meaningless`
+5. Create submission on the same site
+6. Logout
+
+Created content titles are prefixed with `[e2e]` plus a timestamp so they are
+easy to find and delete. **Cleanup is manual** — each full run leaves a new
+question, answer, and submission on the preview test site.
+
+## Env
+
+| Variable | Default |
+|----------|---------|
+| `BASE_URL` | `https://preview.cha.fan` |
+| `E2E_EMAIL` | required (except `--project=public`) |
+| `E2E_PASSWORD` | required (except `--project=public`) |
+| `E2E_SITE_PATH` | `/sites/meaningless` |

--- a/e2e/auth.setup.ts
+++ b/e2e/auth.setup.ts
@@ -1,0 +1,23 @@
+import { test as setup, expect } from '@playwright/test';
+import path from 'node:path';
+import { loginViaUi } from './helpers/login';
+
+const authFile = path.join(__dirname, '.auth/user.json');
+
+setup('authenticate test account', async ({ page }) => {
+  const email = process.env.E2E_EMAIL;
+  const password = process.env.E2E_PASSWORD;
+  if (!email || !password) {
+    throw new Error(
+      'E2E_EMAIL and E2E_PASSWORD must be set (see e2e/env.e2e.example → copy to env.e2e)'
+    );
+  }
+
+  await loginViaUi(page, email, password);
+
+  // Token is stored under chafan:token
+  const token = await page.evaluate(() => localStorage.getItem('chafan:token'));
+  expect(token, 'expected chafan:token after login').toBeTruthy();
+
+  await page.context().storageState({ path: authFile });
+});

--- a/e2e/env.e2e.example
+++ b/e2e/env.e2e.example
@@ -1,0 +1,4 @@
+BASE_URL=https://preview.cha.fan
+E2E_EMAIL=your-test-account@example.com
+E2E_PASSWORD=your-password
+E2E_SITE_PATH=/sites/meaningless

--- a/e2e/fixtures/sites.ts
+++ b/e2e/fixtures/sites.ts
@@ -1,0 +1,5 @@
+/** Stable test site on preview — posts go here. */
+export const TEST_SITE = {
+  path: process.env.E2E_SITE_PATH || '/sites/meaningless',
+  subdomain: 'meaningless',
+};

--- a/e2e/helpers/app.ts
+++ b/e2e/helpers/app.ts
@@ -1,0 +1,63 @@
+import type { Page, Locator } from '@playwright/test';
+import { expect } from '@playwright/test';
+
+/** Vue mounts on #app[data-v-app]; index.html also has a bare #app shell. */
+export function appRoot(page: Page): Locator {
+  return page.locator('#app[data-v-app], .v-application').first();
+}
+
+export async function waitForApp(page: Page) {
+  await expect(appRoot(page)).toBeVisible({ timeout: 30_000 });
+}
+
+/** Ensure Pinia finished checkLoggedIn (avatar appears when profile is loaded). */
+export async function waitForLoggedInShell(page: Page) {
+  await waitForApp(page);
+  await expect(page.getByRole('button', { name: 'Avatar' })).toBeVisible({ timeout: 30_000 });
+  await expect(page.getByRole('link', { name: '用户中心' })).toBeVisible({ timeout: 15_000 });
+}
+
+/**
+ * Vuetify v-btn pointer overlays often block Playwright's synthetic clicks.
+ * DOM element.click() reliably fires Vue @click on preview.cha.fan.
+ */
+export async function clickVuetifyButton(locator: Locator) {
+  await expect(locator).toBeVisible({ timeout: 15_000 });
+  await locator.evaluate((el: HTMLElement) => {
+    el.click();
+  });
+}
+
+/**
+ * Write and publish an answer on the current question page.
+ *
+ * Note: Question.vue auto-opens the answer editor when there are zero answers
+ * (`showEditor = true`). Clicking 「写回答」 toggles it — so do not click if
+ * the editor is already open.
+ */
+export async function writeAndPublishAnswer(page: Page, text: string) {
+  const editorOpen = page.getByText('编辑答案');
+  const publish = page.locator('button.v-btn').filter({ hasText: '发表答案' }).first();
+
+  // Prefer auto-opened editor; only click 写回答 if still closed after load
+  const alreadyOpen = await editorOpen
+    .waitFor({ state: 'visible', timeout: 8_000 })
+    .then(() => true)
+    .catch(() => false);
+
+  if (!alreadyOpen) {
+    const writeBtn = page.locator('button.v-btn.bg-primary').filter({ hasText: '写回答' }).first();
+    await clickVuetifyButton(writeBtn);
+    await expect(editorOpen).toBeVisible({ timeout: 15_000 });
+  }
+
+  await expect(publish).toBeVisible({ timeout: 30_000 });
+
+  const editor = page.locator('[contenteditable="true"]:visible').last();
+  await expect(editor).toBeVisible({ timeout: 15_000 });
+  await editor.click();
+  await page.keyboard.press('ControlOrMeta+a');
+  await page.keyboard.type(text, { delay: 8 });
+
+  await clickVuetifyButton(publish);
+}

--- a/e2e/helpers/login.ts
+++ b/e2e/helpers/login.ts
@@ -1,0 +1,14 @@
+import type { Page } from '@playwright/test';
+
+export async function loginViaUi(page: Page, email: string, password: string) {
+  await page.goto('/login');
+  await page.getByRole('heading', { name: '登录' }).waitFor({ state: 'visible' });
+
+  await page.locator('input[name="login"]').fill(email);
+  await page.locator('input[name="password"], #password').fill(password);
+
+  await page.getByRole('button', { name: '登录', exact: true }).click();
+
+  // Successful login leaves /login (home or reload)
+  await page.waitForURL((url) => !url.pathname.startsWith('/login'), { timeout: 30_000 });
+}

--- a/e2e/helpers/unique.ts
+++ b/e2e/helpers/unique.ts
@@ -1,0 +1,5 @@
+/** Unique suffix so each run creates identifiable content. */
+export function uniqueTitle(prefix: string): string {
+  const ts = new Date().toISOString().replace(/[:.]/g, '-');
+  return `[e2e] ${prefix} ${ts}`;
+}

--- a/e2e/journeys/00-public-browse.spec.ts
+++ b/e2e/journeys/00-public-browse.spec.ts
@@ -1,0 +1,34 @@
+import { test, expect } from '@playwright/test';
+import { TEST_SITE } from '../fixtures/sites';
+import { waitForApp } from '../helpers/app';
+
+/**
+ * Logged-out cold open — does the deploy shell + public pages render?
+ */
+test.describe('Public browse (logged out)', () => {
+  test.use({ storageState: { cookies: [], origins: [] } });
+
+  test('home loads', async ({ page }) => {
+    await page.goto('/');
+    await waitForApp(page);
+    await expect(page.locator('body')).not.toBeEmpty();
+  });
+
+  test('login page shows form', async ({ page }) => {
+    await page.goto('/login');
+    await expect(page.getByRole('heading', { name: '登录' })).toBeVisible();
+    await expect(page.locator('input[name="login"]')).toBeVisible();
+    await expect(page.getByRole('button', { name: '登录', exact: true })).toBeVisible();
+  });
+
+  test('explore page loads', async ({ page }) => {
+    await page.goto('/explore/');
+    await waitForApp(page);
+  });
+
+  test('test site page loads', async ({ page }) => {
+    await page.goto(TEST_SITE.path);
+    await waitForApp(page);
+    await expect(page.getByRole('button', { name: '提问' })).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/e2e/journeys/02-site-and-feed.spec.ts
+++ b/e2e/journeys/02-site-and-feed.spec.ts
@@ -1,0 +1,31 @@
+import { test, expect } from '@playwright/test';
+import { TEST_SITE } from '../fixtures/sites';
+import { waitForLoggedInShell } from '../helpers/app';
+
+/**
+ * Logged-in read paths on the designated test site.
+ */
+test.describe('Logged-in browse', () => {
+  test('home as authenticated user', async ({ page }) => {
+    await page.goto('/');
+    await waitForLoggedInShell(page);
+    await expect(page).not.toHaveURL(/\/login/);
+    const token = await page.evaluate(() => localStorage.getItem('chafan:token'));
+    expect(token).toBeTruthy();
+  });
+
+  test('open test site and switch tabs', async ({ page }) => {
+    await page.goto(TEST_SITE.path);
+    await waitForLoggedInShell(page);
+    await expect(page.getByRole('button', { name: '提问' })).toBeVisible({ timeout: 30_000 });
+
+    const questionsTab = page.getByRole('tab', { name: /问题/ });
+    const submissionsTab = page.getByRole('tab', { name: /分享/ });
+
+    await expect(questionsTab).toBeVisible();
+    await submissionsTab.click();
+    await expect(submissionsTab).toHaveAttribute('aria-selected', 'true');
+    await questionsTab.click();
+    await expect(questionsTab).toHaveAttribute('aria-selected', 'true');
+  });
+});

--- a/e2e/journeys/03-create-question-answer.spec.ts
+++ b/e2e/journeys/03-create-question-answer.spec.ts
@@ -1,0 +1,35 @@
+import { test, expect } from '@playwright/test';
+import { TEST_SITE } from '../fixtures/sites';
+import { uniqueTitle } from '../helpers/unique';
+import { waitForLoggedInShell, writeAndPublishAnswer } from '../helpers/app';
+
+/**
+ * Real create flow: site → 提问 → question page → 写回答 → publish.
+ */
+test.describe('Create question and answer', () => {
+  test('create a question on the test site and post an answer', async ({ page }) => {
+    const questionTitle = uniqueTitle('question');
+    const answerBody = `e2e answer body ${Date.now()}`;
+
+    await page.goto(TEST_SITE.path);
+    await waitForLoggedInShell(page);
+    await expect(page.getByRole('button', { name: '提问' })).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole('button', { name: '提问' }).click();
+    const dialog = page.locator('.v-overlay--active .v-card, .v-dialog--active .v-card').filter({
+      hasText: '提问',
+    });
+    await expect(dialog.getByText('提问').first()).toBeVisible();
+
+    await dialog.locator('textarea').first().fill(questionTitle);
+    await dialog.getByRole('button', { name: '提交新问题' }).click();
+
+    await page.waitForURL(/\/questions\/[^/]+/, { timeout: 30_000 });
+    await expect(page.getByText(questionTitle).first()).toBeVisible({ timeout: 20_000 });
+    await waitForLoggedInShell(page);
+
+    await writeAndPublishAnswer(page, answerBody);
+
+    await expect(page.getByText(answerBody).first()).toBeVisible({ timeout: 30_000 });
+  });
+});

--- a/e2e/journeys/04-create-submission.spec.ts
+++ b/e2e/journeys/04-create-submission.spec.ts
@@ -1,0 +1,37 @@
+import { test, expect } from '@playwright/test';
+import { TEST_SITE } from '../fixtures/sites';
+import { uniqueTitle } from '../helpers/unique';
+import { waitForLoggedInShell } from '../helpers/app';
+
+/**
+ * Real create flow: site → 新分享 → submission detail.
+ */
+test.describe('Create submission', () => {
+  test('create a share on the test site', async ({ page }) => {
+    const title = uniqueTitle('submission');
+
+    await page.goto(TEST_SITE.path);
+    await waitForLoggedInShell(page);
+    await expect(page.getByRole('button', { name: '新分享' })).toBeVisible({ timeout: 30_000 });
+
+    await page.getByRole('button', { name: '新分享' }).click();
+    const dialog = page.locator('.v-overlay--active .v-card, .v-dialog--active .v-card').filter({
+      hasText: '分享',
+    });
+    await expect(dialog.getByText('分享').first()).toBeVisible();
+
+    await dialog.locator('textarea').first().fill(title);
+
+    // Optional URL: leave empty but use a valid optional fill if the field requires one
+    // vee-validate "url" rule often rejects empty string — fill a real URL instead
+    const urlBox = dialog.getByRole('textbox', { name: 'URL（可选）' });
+    if (await urlBox.count()) {
+      await urlBox.fill('https://example.com/e2e');
+    }
+
+    await dialog.getByRole('button', { name: '提交', exact: true }).click();
+
+    await page.waitForURL(/\/submissions\/[^/]+/, { timeout: 45_000 });
+    await expect(page.getByText(title).first()).toBeVisible({ timeout: 20_000 });
+  });
+});

--- a/e2e/journeys/05-logout.spec.ts
+++ b/e2e/journeys/05-logout.spec.ts
@@ -1,0 +1,46 @@
+import { test, expect } from '@playwright/test';
+import { waitForLoggedInShell, clickVuetifyButton } from '../helpers/app';
+
+/**
+ * Exercise the real logout path: avatar menu → 登出.
+ * Falls back to clearing the token if the menu item can't be reached, so a
+ * changed menu still leaves the test in a verified logged-out state.
+ */
+test.describe('Logout', () => {
+  test('log out via avatar menu and see login again', async ({ page }) => {
+    await page.goto('/');
+    await waitForLoggedInShell(page);
+
+    const loggedOutViaUi = await logoutViaMenu(page).catch(() => false);
+    if (!loggedOutViaUi) {
+      await page.evaluate(() => localStorage.removeItem('chafan:token'));
+      await page.reload();
+    }
+
+    // Token is gone regardless of path.
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem('chafan:token')))
+      .toBeNull();
+
+    // And the login page renders again.
+    await page.goto('/login');
+    await expect(page.getByRole('heading', { name: '登录' })).toBeVisible();
+    await expect(page.getByRole('button', { name: '登录', exact: true })).toBeVisible();
+  });
+});
+
+/** Open the avatar menu and click 登出. Returns true if the token cleared. */
+async function logoutViaMenu(page: import('@playwright/test').Page): Promise<boolean> {
+  await clickVuetifyButton(page.getByRole('button', { name: 'Avatar' }));
+
+  const logout = page
+    .locator('.v-overlay--active .v-list-item, .v-menu .v-list-item')
+    .filter({ hasText: '登出' })
+    .first();
+  await clickVuetifyButton(logout);
+
+  await expect
+    .poll(() => page.evaluate(() => localStorage.getItem('chafan:token')), { timeout: 15_000 })
+    .toBeNull();
+  return true;
+}

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -1,0 +1,57 @@
+import { defineConfig, devices } from '@playwright/test';
+import dotenv from 'dotenv';
+import path from 'node:path';
+
+// Load secrets from repo-root env.e2e (gitignored)
+dotenv.config({ path: path.resolve(__dirname, '../env.e2e') });
+
+const baseURL = process.env.BASE_URL || 'https://preview.cha.fan';
+
+export default defineConfig({
+  testDir: path.join(__dirname, 'journeys'),
+  fullyParallel: false,
+  workers: 1,
+  retries: 1,
+  timeout: 90_000,
+  expect: { timeout: 15_000 },
+  forbidOnly: !!process.env.CI,
+  reporter: [
+    ['list'],
+    ['html', { open: 'never', outputFolder: path.resolve(__dirname, '../playwright-report') }],
+  ],
+  outputDir: path.resolve(__dirname, '../test-results'),
+  use: {
+    baseURL,
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    locale: 'zh-CN',
+    timezoneId: 'Asia/Shanghai',
+    viewport: { width: 1280, height: 800 },
+    actionTimeout: 15_000,
+    navigationTimeout: 45_000,
+    // Avoid stale PWA shells after deploys
+    serviceWorkers: 'block',
+  },
+  projects: [
+    {
+      name: 'setup',
+      testMatch: /auth\.setup\.ts/,
+      testDir: __dirname,
+    },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: path.join(__dirname, '.auth/user.json'),
+      },
+      dependencies: ['setup'],
+      testIgnore: /00-public/,
+    },
+    {
+      name: 'public',
+      use: { ...devices['Desktop Chrome'] },
+      testMatch: /00-public/,
+    },
+  ],
+});

--- a/e2e/run.sh
+++ b/e2e/run.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#
+# Standalone launcher for the preview E2E suite.
+# No yarn run-scripts needed — this drives Playwright directly.
+#
+# Usage:
+#   e2e/run.sh                 # headless, all journeys
+#   e2e/run.sh --headed        # watch the browser
+#   e2e/run.sh --ui            # Playwright UI mode
+#   e2e/run.sh --project=public   # only logged-out journeys (no credentials)
+#   e2e/run.sh e2e/journeys/03-create-question-answer.spec.ts   # a single journey
+#
+# Any extra args are passed straight through to `playwright test`.
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+cd "$ROOT"
+
+if [ ! -x "node_modules/.bin/playwright" ]; then
+  echo "Playwright is not installed. Run 'yarn install' first." >&2
+  exit 1
+fi
+
+# The 'public' project needs no credentials; everything else does.
+wants_public_only=false
+for arg in "$@"; do
+  [ "$arg" = "--project=public" ] && wants_public_only=true
+done
+
+if [ "$wants_public_only" = false ] && [ ! -f "$ROOT/env.e2e" ]; then
+  echo "Missing env.e2e — copy e2e/env.e2e.example to env.e2e and fill" >&2
+  echo "E2E_EMAIL / E2E_PASSWORD, or run only the public journeys:" >&2
+  echo "  e2e/run.sh --project=public" >&2
+  exit 1
+fi
+
+# Ensure the chromium binary is present (no-op once cached).
+node_modules/.bin/playwright install chromium >/dev/null 2>&1 || \
+  node_modules/.bin/playwright install chromium
+
+exec node_modules/.bin/playwright test --config "$HERE/playwright.config.ts" "$@"

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "devDependencies": {
     "@mdi/js": "^7.4.47",
+    "@playwright/test": "^1.61.1",
     "@types/diff": "^5.2.3",
     "@types/lodash": "^4.17.21",
     "@types/node": "^22.15.0",
@@ -67,6 +68,7 @@
     "@vue/eslint-config-typescript": "^14.7.0",
     "@vue/test-utils": "^2.4.6",
     "autoprefixer": "^10.4.23",
+    "dotenv": "^17.4.2",
     "eslint": "^10.1.0",
     "eslint-plugin-vue": "^10.8.0",
     "jsdom": "^25.0.1",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -119,6 +119,8 @@ export default defineConfig(({ mode }) => {
     test: {
       environment: 'jsdom',
       globals: true,
+      // Vitest owns tests/; e2e/ is Playwright's and must not be collected here.
+      include: ['tests/**/*.spec.ts'],
       server: {
         deps: {
           inline: ['vuetify'],

--- a/yarn.lock
+++ b/yarn.lock
@@ -2017,6 +2017,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.61.1":
+  version: 1.61.1
+  resolution: "@playwright/test@npm:1.61.1"
+  dependencies:
+    playwright: "npm:1.61.1"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/45004139eaa7c7ec8129e4ed77a9d734aa09ed40b69162b871e4123f1d70217b7b73651431a9343ed5090d5fed11c6df1bff2a56ff4b87dc7b0371b5da87cf9c
+  languageName: node
+  linkType: hard
+
 "@popperjs/core@npm:^2.9.0":
   version: 2.11.8
   resolution: "@popperjs/core@npm:2.11.8"
@@ -3755,6 +3766,7 @@ __metadata:
   resolution: "chafan-pwa@workspace:."
   dependencies:
     "@mdi/js": "npm:^7.4.47"
+    "@playwright/test": "npm:^1.61.1"
     "@sentry/vue": "npm:^8.55.0"
     "@tiptap/core": "npm:^2.11.0"
     "@tiptap/extension-code-block": "npm:^2.11.0"
@@ -3783,6 +3795,7 @@ __metadata:
     dayjs: "npm:^1.11.19"
     diff: "npm:^5.2.0"
     dompurify: "npm:^3.4.11"
+    dotenv: "npm:^17.4.2"
     eslint: "npm:^10.1.0"
     eslint-plugin-vue: "npm:^10.8.0"
     get-youtube-id: "npm:^1.0.1"
@@ -4317,6 +4330,13 @@ __metadata:
     domelementtype: "npm:^2.3.0"
     domhandler: "npm:^5.0.3"
   checksum: 10c0/47938f473b987ea71cd59e59626eb8666d3aa8feba5266e45527f3b636c7883cca7e582d901531961f742c519d7514636b7973353b648762b2e3bedbf235fada
+  languageName: node
+  linkType: hard
+
+"dotenv@npm:^17.4.2":
+  version: 17.4.2
+  resolution: "dotenv@npm:17.4.2"
+  checksum: 10c0/164f8e77a646c8446867d5b588d26ea6005c8ea7c5eb41cf926f6113d23f2191355f6e0cfd95ea9bab98394a5b0a3f1e51a8399711b666fe55cc7b0bd745f942
   languageName: node
   linkType: hard
 
@@ -5181,12 +5201,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -7008,6 +7047,30 @@ __metadata:
     typescript:
       optional: true
   checksum: 10c0/e005883c26fe782e26803859db8703ead2e7053271d22828175c82d56e925ddab65ca2543a3f3a36686a11e6835f60c031f1eb2ef9159f9da05121495499c5f6
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright-core@npm:1.61.1"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/c28896ba82a602182e240ed4f9c467fb0dd9cb57d510f8aba9f25183fe1cde3a0105725a29baffa4157fe885bbb11e228032a2aad0424111584fde45303f07bd
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.61.1":
+  version: 1.61.1
+  resolution: "playwright@npm:1.61.1"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.61.1"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/cea1bc4d2a64ec3ef683891606774029da7b8a8036ed98332565cec2f8e89549ca1fab9a89fbfba4e08e27e0d7e7d148031e965af66d5ff97bb3c34058cfcad0
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Real-browser Playwright journeys against preview.cha.fan, for manual post-deploy smoke checks. **Not wired into CI** — run by hand after promoting to preview.

## What's here

- `e2e/run.sh` — standalone launcher, drives Playwright directly (no yarn run-scripts). Extra args pass through to `playwright test`.
- Six journeys: public browse (no credentials), logged-in site tabs, create question + answer, create submission, logout via the real avatar menu.
- `@playwright/test` + `dotenv` added as devDependencies.

## Running it

```bash
yarn install
yarn playwright install chromium
cp e2e/env.e2e.example env.e2e   # fill E2E_EMAIL / E2E_PASSWORD
e2e/run.sh                       # or: e2e/run.sh --project=public (no credentials)
```

See `e2e/README.md` for details.

## Notes for reviewers

- **Credentials** live in `env.e2e`, which is gitignored — only the placeholder `env.e2e.example` is committed. Saved auth state (`e2e/.auth/`) and run artifacts (`playwright-report/`, `test-results/`) are ignored too. (These `.gitignore` entries have since landed on `master` independently, so this branch no longer touches that file.)
- **Vitest is now scoped to `tests/`** (`vite.config.ts`: `test.include = ['tests/**/*.spec.ts']`). Without it, `vitest run` collects `e2e/journeys/*.spec.ts` and dies with *"Playwright Test did not expect test.describe() to be called here"* — that was the original CI failure on this PR. The two runners now own disjoint directories.
- **The mutating journeys write real content to the preview test site** (`/sites/meaningless`). Titles are prefixed `[e2e]` plus a timestamp so they're easy to find; **cleanup is manual** — each full run leaves a question, an answer, and a submission behind.
- **`e2e/` is not covered by `tsconfig.json` or `yarn lint`** (both scoped to `src/`/`tests/`), so this TypeScript isn't typechecked. Deliberate for now — adding it to `include` would pull e2e into `vue-tsc` on every build. Happy to change if preferred.
- Journey files are numbered 00, 02–05; the login step lives in `auth.setup.ts` rather than a `01` journey.
- CI impact: two devDependencies plus the three-line `test.include` in `vite.config.ts`. Nothing under `src/` or `tests/` changes.

Verified: all 10 journeys pass against preview.cha.fan.

---

**Rebased onto `master` @ cb7865c** (was based on `0e0c081`, four commits behind). Only conflict was `.gitignore`, resolved by dropping this branch's now-duplicate entries in favour of master's. Locally re-verified the full CI sequence against the rebased tree: `yarn install --immutable`, `lint` (0 errors), `lint:css`, `test:unit` (10 files / 106 tests pass, no e2e collected), and `cloudflare.build.sh`. `typecheck` reports 291 errors both here and on `master` — unchanged. `playwright test --list` still enumerates all 10 journeys across the `setup`/`chromium`/`public` projects.
